### PR TITLE
Result of the actioncontroller

### DIFF
--- a/actioncontroller/action.go
+++ b/actioncontroller/action.go
@@ -1,4 +1,4 @@
-package actiondispatch
+package actioncontroller
 
 import (
 	"context"
@@ -9,18 +9,23 @@ import (
 type Context struct {
 	context.Context
 
-	Params map[string]interface{}
+	Params Parameters
+}
+
+// Result defines a contract that represents the result of action method.
+type Result interface {
+	Execute(*Context) (interface{}, error)
 }
 
 type Action interface {
 	ActionName() string
 	ActionRequest() []activerecord.Attribute
-	Process(ctx *Context) error
+	Process(ctx *Context) Result
 }
 
-type AnonymousAction func(*Context) error
+type AnonymousAction func(*Context) Result
 
-func (fn AnonymousAction) Process(ctx *Context) error {
+func (fn AnonymousAction) Process(ctx *Context) Result {
 	return fn(ctx)
 }
 

--- a/actioncontroller/controller.go
+++ b/actioncontroller/controller.go
@@ -1,11 +1,10 @@
 package actioncontroller
 
 import (
-	"github.com/activegraph/activegraph/actiondispatch"
 	"github.com/activegraph/activegraph/activerecord"
 )
 
-type actionsMap map[string]*actiondispatch.NamedAction
+type actionsMap map[string]*NamedAction
 
 func (m actionsMap) copy() actionsMap {
 	mm := make(actionsMap, len(m))
@@ -29,8 +28,8 @@ func (c *C) AfterAction() {
 func (c *C) AroundAction() {
 }
 
-func (c *C) Action(name string, a actiondispatch.AnonymousAction) {
-	c.actions[name] = &actiondispatch.NamedAction{Name: name, AnonymousAction: a}
+func (c *C) Action(name string, a AnonymousAction) {
+	c.actions[name] = &NamedAction{Name: name, AnonymousAction: a}
 }
 
 func (c *C) Permit(params []activerecord.Attribute, names ...string) {
@@ -40,24 +39,24 @@ func (c *C) Permit(params []activerecord.Attribute, names ...string) {
 	}
 }
 
-func (c *C) Create(a actiondispatch.AnonymousAction) {
-	c.Action(actiondispatch.ActionCreate, a)
+func (c *C) Create(a AnonymousAction) {
+	c.Action(ActionCreate, a)
 }
 
-func (c *C) Update(a actiondispatch.AnonymousAction) {
-	c.Action(actiondispatch.ActionUpdate, a)
+func (c *C) Update(a AnonymousAction) {
+	c.Action(ActionUpdate, a)
 }
 
-func (c *C) Show(a actiondispatch.AnonymousAction) {
-	c.Action(actiondispatch.ActionShow, a)
+func (c *C) Show(a AnonymousAction) {
+	c.Action(ActionShow, a)
 }
 
-func (c *C) Index(a actiondispatch.AnonymousAction) {
-	c.Action(actiondispatch.ActionIndex, a)
+func (c *C) Index(a AnonymousAction) {
+	c.Action(ActionIndex, a)
 }
 
-func (c *C) Destroy(a actiondispatch.AnonymousAction) {
-	c.Action(actiondispatch.ActionDestroy, a)
+func (c *C) Destroy(a AnonymousAction) {
+	c.Action(ActionDestroy, a)
 }
 
 type ActionController struct {
@@ -90,8 +89,8 @@ func (c *ActionController) HasAction(actionName string) bool {
 	return ok
 }
 
-func (c *ActionController) ActionMethods() []actiondispatch.Action {
-	actions := make([]actiondispatch.Action, 0, len(c.actions))
+func (c *ActionController) ActionMethods() []Action {
+	actions := make([]Action, 0, len(c.actions))
 	for _, action := range c.actions {
 		actions = append(actions, action)
 	}

--- a/actioncontroller/graphql/mapper.go
+++ b/actioncontroller/graphql/mapper.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/activegraph/activegraph/actiondispatch"
+	"github.com/activegraph/activegraph/actioncontroller"
 	"github.com/activegraph/activegraph/activerecord"
 
 	"github.com/graphql-go/graphql"
@@ -23,8 +23,8 @@ func typeconv(t string) graphql.Type {
 }
 
 type resource struct {
-	model      actiondispatch.AbstractModel
-	controller actiondispatch.AbstractController
+	model      actioncontroller.AbstractModel
+	controller actioncontroller.AbstractController
 }
 
 type Mapper struct {
@@ -32,12 +32,12 @@ type Mapper struct {
 }
 
 func (m *Mapper) Resources(
-	model actiondispatch.AbstractModel, controller actiondispatch.AbstractController,
+	model actioncontroller.AbstractModel, controller actioncontroller.AbstractController,
 ) {
 	m.resources = append(m.resources, resource{model, controller})
 }
 
-func (m *Mapper) primaryKey(model actiondispatch.AbstractModel) graphql.FieldConfigArgument {
+func (m *Mapper) primaryKey(model actioncontroller.AbstractModel) graphql.FieldConfigArgument {
 	return graphql.FieldConfigArgument{
 		model.PrimaryKey(): &graphql.ArgumentConfig{
 			Type: graphql.NewNonNull(
@@ -48,7 +48,7 @@ func (m *Mapper) primaryKey(model actiondispatch.AbstractModel) graphql.FieldCon
 }
 
 func (m *Mapper) newIndexAction(
-	model actiondispatch.AbstractModel, output graphql.Output, action actiondispatch.Action,
+	model actioncontroller.AbstractModel, output graphql.Output, action actioncontroller.Action,
 ) *graphql.Field {
 
 	args := make(graphql.FieldConfigArgument, len(action.ActionRequest()))
@@ -63,8 +63,8 @@ func (m *Mapper) newIndexAction(
 		Args: args,
 		Type: graphql.NewList(output),
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-			action.Process(&actiondispatch.Context{
-				Params: p.Args, Context: p.Context,
+			action.Process(&actioncontroller.Context{
+				Params: actioncontroller.Parameters(p.Args), Context: p.Context,
 			})
 			return nil, nil
 		},
@@ -72,15 +72,15 @@ func (m *Mapper) newIndexAction(
 }
 
 func (m *Mapper) newShowAction(
-	model actiondispatch.AbstractModel, output graphql.Output, action actiondispatch.Action,
+	model actioncontroller.AbstractModel, output graphql.Output, action actioncontroller.Action,
 ) *graphql.Field {
 	return &graphql.Field{
 		Name: model.Name(),
 		Args: m.primaryKey(model),
 		Type: output,
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-			action.Process(&actiondispatch.Context{
-				Params: p.Args, Context: p.Context,
+			action.Process(&actioncontroller.Context{
+				Params: actioncontroller.Parameters(p.Args), Context: p.Context,
 			})
 			return nil, nil
 		},
@@ -88,7 +88,7 @@ func (m *Mapper) newShowAction(
 }
 
 func (m *Mapper) newUpdateAction(
-	operation string, model actiondispatch.AbstractModel, output graphql.Output, action actiondispatch.Action,
+	operation string, model actioncontroller.AbstractModel, output graphql.Output, action actioncontroller.Action,
 ) *graphql.Field {
 
 	objFields := make(graphql.InputObjectConfigFieldMap, len(action.ActionRequest()))
@@ -99,7 +99,6 @@ func (m *Mapper) newUpdateAction(
 	}
 
 	args := graphql.FieldConfigArgument{
-		model.PrimaryKey(): m.primaryKey(model)[model.PrimaryKey()],
 		model.Name(): &graphql.ArgumentConfig{
 			Type: graphql.NewNonNull(graphql.NewInputObject(graphql.InputObjectConfig{
 				Name:   strings.Title(operation) + strings.Title(model.Name()) + "Input",
@@ -108,29 +107,36 @@ func (m *Mapper) newUpdateAction(
 		},
 	}
 
+	// TODO: separate creation and update
+	if operation == "update" {
+		args[model.PrimaryKey()] = m.primaryKey(model)[model.PrimaryKey()]
+	}
+
 	return &graphql.Field{
 		Name: operation + strings.Title(model.Name()),
 		Args: args,
 		Type: output,
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-			action.Process(&actiondispatch.Context{
-				Params: p.Args, Context: p.Context,
-			})
-			return nil, nil
+			context := &actioncontroller.Context{
+				Context: p.Context,
+				Params:  actioncontroller.Parameters(p.Args),
+			}
+			result := action.Process(context)
+			return result.Execute(context)
 		},
 	}
 }
 
 func (m *Mapper) newDestroyAction(
-	model actiondispatch.AbstractModel, output graphql.Output, action actiondispatch.Action,
+	model actioncontroller.AbstractModel, output graphql.Output, action actioncontroller.Action,
 ) *graphql.Field {
 	return &graphql.Field{
 		Name: "delete" + strings.Title(model.Name()),
 		Args: m.primaryKey(model),
 		Type: output,
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-			action.Process(&actiondispatch.Context{
-				Params: p.Args, Context: p.Context,
+			action.Process(&actioncontroller.Context{
+				Params: actioncontroller.Parameters(p.Args), Context: p.Context,
 			})
 			return nil, nil
 		},
@@ -158,16 +164,16 @@ func (m *Mapper) Map() (http.Handler, error) {
 
 		for _, action := range resource.controller.ActionMethods() {
 			switch action.ActionName() {
-			case actiondispatch.ActionIndex:
+			case actioncontroller.ActionIndex:
 				query := m.newIndexAction(resource.model, output, action)
 				queries[query.Name] = query
-			case actiondispatch.ActionShow:
+			case actioncontroller.ActionShow:
 				query := m.newShowAction(resource.model, output, action)
 				queries[query.Name] = query
-			case actiondispatch.ActionUpdate, actiondispatch.ActionCreate:
+			case actioncontroller.ActionUpdate, actioncontroller.ActionCreate:
 				mutation := m.newUpdateAction(action.ActionName(), resource.model, output, action)
 				mutations[mutation.Name] = mutation
-			case actiondispatch.ActionDestroy:
+			case actioncontroller.ActionDestroy:
 				mutation := m.newDestroyAction(resource.model, output, action)
 				mutations[mutation.Name] = mutation
 			}

--- a/actioncontroller/parameters.go
+++ b/actioncontroller/parameters.go
@@ -1,0 +1,19 @@
+package actioncontroller
+
+type Parameters map[string]interface{}
+
+func (p Parameters) Get(key string) Parameters {
+	val, ok := p[key]
+	if !ok {
+		return nil
+	}
+	params, ok := val.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return params
+}
+
+func (p Parameters) ToH() map[string]interface{} {
+	return (map[string]interface{})(p)
+}

--- a/actioncontroller/request.go
+++ b/actioncontroller/request.go
@@ -1,4 +1,4 @@
-package actiondispatch
+package actioncontroller
 
 type Request struct {
 }

--- a/actioncontroller/routing.go
+++ b/actioncontroller/routing.go
@@ -1,4 +1,4 @@
-package actiondispatch
+package actioncontroller
 
 import (
 	"net/http"

--- a/actionview/result.go
+++ b/actionview/result.go
@@ -1,0 +1,29 @@
+package actionview
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/activegraph/activegraph/actioncontroller"
+	"github.com/activegraph/activegraph/activesupport"
+)
+
+type ResultFunc func(*actioncontroller.Context) (interface{}, error)
+
+func (fn ResultFunc) Execute(ctx *actioncontroller.Context) (interface{}, error) {
+	return fn(ctx)
+}
+
+func ViewResult(res activesupport.Res) actioncontroller.Result {
+	return ResultFunc(func(ctx *actioncontroller.Context) (interface{}, error) {
+		if res.Err() != nil {
+			return nil, res.Err()
+		}
+
+		val, ok := res.Ok().(activesupport.HashConverter)
+		if !ok {
+			return nil, errors.Errorf("%T does not support hash conversion", val)
+		}
+
+		return val.ToHash(), nil
+	})
+}

--- a/activerecord/record.go
+++ b/activerecord/record.go
@@ -27,6 +27,10 @@ type ActiveRecord struct {
 	associationRecords map[string]*ActiveRecord
 }
 
+func (r *ActiveRecord) ToHash() map[string]interface{} {
+	return r.attributes.values
+}
+
 func (r *ActiveRecord) Name() string {
 	return r.name
 }

--- a/activesupport/hash.go
+++ b/activesupport/hash.go
@@ -1,0 +1,5 @@
+package activesupport
+
+type HashConverter interface {
+	ToHash() map[string]interface{}
+}

--- a/activesupport/result.go
+++ b/activesupport/result.go
@@ -1,0 +1,29 @@
+package activesupport
+
+type Res interface {
+	Ok() interface{}
+	Err() error
+}
+
+type res struct {
+	ok  interface{}
+	err error
+}
+
+func (r res) Ok() interface{} {
+	if r.err != nil {
+		return nil
+	}
+	return r.ok
+}
+
+func (r res) Err() error {
+	if r.err != nil {
+		return r.err
+	}
+	return nil
+}
+
+func Result(val interface{}, err error) Res {
+	return res{ok: val, err: err}
+}

--- a/application.go
+++ b/application.go
@@ -3,16 +3,16 @@ package activegraph
 import (
 	"net/http"
 
-	"github.com/activegraph/activegraph/actiondispatch"
-	"github.com/activegraph/activegraph/actiondispatch/graphql"
+	"github.com/activegraph/activegraph/actioncontroller"
+	"github.com/activegraph/activegraph/actioncontroller/graphql"
 )
 
 type A struct {
-	actiondispatch.Mapper
+	actioncontroller.Mapper
 }
 
 type Application struct {
-	mapper actiondispatch.Mapper
+	mapper actioncontroller.Mapper
 }
 
 func New(init func(*A)) *Application {


### PR DESCRIPTION
This patch borrow approach from ASP.NET of returning results from
actions through encapsulated instance of `actioncontroller.Result`
type.