### PR TITLE
Introduce route matching constraints

### DIFF
--- a/actioncontroller/controller.go
+++ b/actioncontroller/controller.go
@@ -19,13 +19,13 @@ type C struct {
 	params  map[string][]activerecord.Attribute
 }
 
-func (c *C) BeforeAction(only ...string) {
+func (c *C) BeforeAction(action AnonymousAction, only ...string) {
 }
 
-func (c *C) AfterAction() {
+func (c *C) AfterAction(action AnonymousAction, only ...string) {
 }
 
-func (c *C) AroundAction() {
+func (c *C) AroundAction(action AnonymousAction, only ...string) {
 }
 
 func (c *C) Action(name string, a AnonymousAction) {
@@ -95,4 +95,12 @@ func (c *ActionController) ActionMethods() []Action {
 		actions = append(actions, action)
 	}
 	return actions
+}
+
+func (c *ActionController) Action(actionName string) Action {
+	action, ok := c.actions[actionName]
+	if !ok {
+		return nil
+	}
+	return action
 }

--- a/actioncontroller/parameters.go
+++ b/actioncontroller/parameters.go
@@ -1,5 +1,9 @@
 package actioncontroller
 
+import (
+	"github.com/activegraph/activegraph/activerecord"
+)
+
 type Parameters map[string]interface{}
 
 func (p Parameters) Get(key string) Parameters {
@@ -16,4 +20,20 @@ func (p Parameters) Get(key string) Parameters {
 
 func (p Parameters) ToH() map[string]interface{} {
 	return (map[string]interface{})(p)
+}
+
+type StrongParameters struct {
+	Attributes []activerecord.Attribute
+}
+
+func (p *StrongParameters) Permit(names ...string) *StrongParameters {
+	attrs := make([]activerecord.Attribute, 0, len(names))
+	for _, attr := range p.Attributes {
+		attrs = append(attrs, attr)
+	}
+	return &StrongParameters{Attributes: attrs}
+}
+
+func Require(rel *activerecord.Relation) *StrongParameters {
+	return &StrongParameters{Attributes: rel.AttributesForInspect()}
 }

--- a/actioncontroller/routing.go
+++ b/actioncontroller/routing.go
@@ -11,13 +11,28 @@ type AbstractModel interface {
 	PrimaryKey() string
 	AttributeNames() []string
 	AttributeForInspect(attrName string) activerecord.Attribute
+	AttributesForInspect(attrNames ...string) []activerecord.Attribute
 }
 
 type AbstractController interface {
 	ActionMethods() []Action
 }
 
+type Matcher interface {
+	Matches(*Request) bool
+}
+
+type Constraints struct {
+	Request  *StrongParameters
+	Response *StrongParameters
+	Match    Matcher
+}
+
 type Mapper interface {
 	Resources(AbstractModel, AbstractController)
+
+	// Match matches path to an action.
+	Match(via, path string, action Action, constraints ...Constraints)
+
 	Map() (http.Handler, error)
 }

--- a/activerecord/attibute.go
+++ b/activerecord/attibute.go
@@ -307,6 +307,9 @@ func (a *attributes) AttributeForInspect(attrName string) Attribute {
 
 func (a *attributes) AttributesForInspect(attrNames ...string) []Attribute {
 	attrs := make([]Attribute, 0, len(attrNames))
+	if len(attrNames) == 0 {
+		attrNames = a.AttributeNames()
+	}
 	for _, attrName := range attrNames {
 		if a.HasAttribute(attrName) {
 			attrs = append(attrs, a.keys[attrName])


### PR DESCRIPTION
This patch allows to specify routing constraints for route mapper.
With request/response constraints now it's easy to declare GraphQL actions.'