### PR TITLE
Replace "internal.Copy" with "Hash.Copy"

### DIFF
--- a/activerecord/attibute.go
+++ b/activerecord/attibute.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/activegraph/activegraph/activesupport"
-	"github.com/activegraph/activegraph/internal"
 )
 
 const (
@@ -110,7 +109,7 @@ func (a *attributes) copy() *attributes {
 		recordName: a.recordName,
 		primaryKey: a.primaryKey,
 		keys:       a.keys.copy(),
-		values:     internal.CopyMap(a.values),
+		values:     a.values.Copy(),
 	}
 }
 
@@ -261,7 +260,7 @@ func (a *attributes) AssignAttributes(newAttributes map[string]interface{}) erro
 	// return the object in the previous state.
 	var (
 		keys   = a.keys.copy()
-		values = internal.CopyMap(a.values)
+		values = a.values.Copy()
 	)
 
 	for attrName, val := range newAttributes {

--- a/activesupport/hash.go
+++ b/activesupport/hash.go
@@ -2,6 +2,14 @@ package activesupport
 
 type Hash map[string]interface{}
 
+func (h Hash) Copy() Hash {
+	hcopy := make(Hash, len(h))
+	for k, v := range h {
+		hcopy[k] = v
+	}
+	return hcopy
+}
+
 type HashConverter interface {
 	ToHash() Hash
 }

--- a/internal/copy.go
+++ b/internal/copy.go
@@ -1,9 +1,0 @@
-package internal
-
-func CopyMap(m map[string]interface{}) map[string]interface{} {
-	mout := make(map[string]interface{})
-	for k, v := range m {
-		mout[k] = v
-	}
-	return mout
-}


### PR DESCRIPTION
This patch replaces internal Copy methods with Copy method of Hash type.