### PR TITLE
Allow empty "New" call

### DIFF
--- a/activerecord/relation.go
+++ b/activerecord/relation.go
@@ -214,8 +214,15 @@ func (rel *Relation) Connection() Conn {
 	return conn
 }
 
-func (rel *Relation) New(params map[string]interface{}) Result {
-	return Return(rel.Initialize(params))
+func (rel *Relation) New(params ...map[string]interface{}) Result {
+	switch len(params) {
+	case 0:
+		return Return(rel.Initialize(nil))
+	case 1:
+		return Return(rel.Initialize(params[0]))
+	default:
+		return Err(&activesupport.ErrMultipleVariadicArguments{Name: "params"})
+	}
 }
 
 func (rel *Relation) Initialize(params map[string]interface{}) (*ActiveRecord, error) {

--- a/activerecord/relation_test.go
+++ b/activerecord/relation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/activegraph/activegraph/activerecord"
 	_ "github.com/activegraph/activegraph/activerecord/sqlite3"
+	"github.com/activegraph/activegraph/activesupport"
 )
 
 func initAuthorTable(t *testing.T, conn activerecord.Conn) {
@@ -37,6 +38,35 @@ func initBookTable(t *testing.T, conn activerecord.Conn) {
 		);
 	`)
 	require.NoError(t, err)
+}
+
+func TestRelation_New(t *testing.T) {
+	Product := activerecord.New("product", func(r *activerecord.R) {
+		r.AttrString("name")
+	})
+
+	p := Product.New(activesupport.Hash{"name": "Vacuum Cleaner"})
+	require.NoError(t, p.Err())
+	require.Equal(t, p.UnwrapRecord().Attribute("name"), "Vacuum Cleaner")
+}
+
+func TestRelation_New_WithoutParams(t *testing.T) {
+	Product := activerecord.New("product", func(r *activerecord.R) {
+		r.AttrString("name")
+	})
+
+	p := Product.New().UnwrapRecord()
+	require.NoError(t, p.AssignAttribute("name", "Holy Grail"))
+}
+
+func TestRelation_New_MultipleParams(t *testing.T) {
+	Product := activerecord.New("product", func(r *activerecord.R) {})
+	p := Product.New(activesupport.Hash{}, activesupport.Hash{})
+
+	require.Error(t, p.Err())
+
+	err := &activesupport.ErrMultipleVariadicArguments{Name: "params"}
+	require.Equal(t, err.Error(), p.Err().Error())
 }
 
 func TestRelation_Limit(t *testing.T) {

--- a/activesupport/error.go
+++ b/activesupport/error.go
@@ -1,0 +1,13 @@
+package activesupport
+
+import (
+	"fmt"
+)
+
+type ErrMultipleVariadicArguments struct {
+	Name string
+}
+
+func (e *ErrMultipleVariadicArguments) Error() string {
+	return fmt.Sprintf("Only one variadic argument for '%s' permitted", e.Name)
+}


### PR DESCRIPTION
This patch allows to create an Active Record from relation without assigned parameters.

Closes #56 