### PR TITLE
Naive Eager loading for SQLite3

### DIFF
--- a/activerecord/attibute.go
+++ b/activerecord/attibute.go
@@ -153,7 +153,7 @@ func newAttributes(recordName string, attrs attributesMap, values activesupport.
 	// When the primary key attribute was not specified directly, generate
 	// a new "id" integer attribute, ensure that the attribute with the same
 	// name is not presented in the schema definition.
-	if _, dup := recordAttrs.keys[defaultPrimaryKeyName]; dup {
+	if _, dup := recordAttrs.keys[defaultPrimaryKeyName]; dup && recordAttrs.primaryKey == nil {
 		err := errors.Errorf("%q is an attribute, but not a primary key", defaultPrimaryKeyName)
 		return nil, err
 	}

--- a/activerecord/persistence.go
+++ b/activerecord/persistence.go
@@ -38,6 +38,13 @@ type QueryOperation struct {
 	Columns []string
 }
 
+type ColumnDefinition struct {
+	Name         string
+	Type         string
+	NotNull      bool
+	IsPrimaryKey bool
+}
+
 type Conn interface {
 	BeginTransaction(ctx context.Context) (Conn, error)
 	CommitTransaction(ctx context.Context) error
@@ -47,6 +54,8 @@ type Conn interface {
 	ExecInsert(ctx context.Context, op *InsertOperation) (id interface{}, err error)
 	ExecDelete(ctx context.Context, op *DeleteOperation) (err error)
 	ExecQuery(ctx context.Context, op *QueryOperation, cb func(activesupport.Hash) bool) (err error)
+
+	ColumnDefinitions(ctx context.Context, tableName string) ([]ColumnDefinition, error)
 
 	Close() error
 }
@@ -81,6 +90,10 @@ func (c *errConn) ExecDelete(context.Context, *DeleteOperation) error {
 
 func (c *errConn) ExecQuery(context.Context, *QueryOperation, func(activesupport.Hash) bool) error {
 	return c.err
+}
+
+func (c *errConn) ColumnDefinitions(ctx context.Context, tableName string) ([]ColumnDefinition, error) {
+	return nil, c.err
 }
 
 func (c *errConn) Close() error {

--- a/activerecord/relation_test.go
+++ b/activerecord/relation_test.go
@@ -41,13 +41,22 @@ func initBookTable(t *testing.T, conn activerecord.Conn) {
 }
 
 func TestRelation_New(t *testing.T) {
-	Product := activerecord.New("product", func(r *activerecord.R) {
-		r.AttrString("name")
+	conn, _ := activerecord.EstablishConnection(activerecord.DatabaseConfig{
+		Adapter:  "sqlite3",
+		Database: t.Name() + ".db",
 	})
 
-	p := Product.New(activesupport.Hash{"name": "Vacuum Cleaner"})
-	require.NoError(t, p.Err())
-	require.Equal(t, p.UnwrapRecord().Attribute("name"), "Vacuum Cleaner")
+	defer os.Remove(t.Name() + ".db")
+	defer activerecord.RemoveConnection("primary")
+
+	initAuthorTable(t, conn)
+
+	Author := activerecord.New("author")
+	a := Author.New(activesupport.Hash{"name": "Nassim Taleb"})
+	a = a.Insert()
+
+	require.NoError(t, a.Err())
+	require.Equal(t, a.UnwrapRecord().Attribute("name"), "Nassim Taleb")
 }
 
 func TestRelation_New_WithoutParams(t *testing.T) {


### PR DESCRIPTION
This patch provides naive implementation of eager loading for SQLite 3.
It supports only INTEGER and VARCHAR (wuthout length).