### PR TITLE
Add error type to record validation errors

### DIFF
--- a/activerecord/validations.go
+++ b/activerecord/validations.go
@@ -3,11 +3,22 @@ package activerecord
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/activegraph/activegraph/activesupport"
 )
+
+type ErrValidation struct {
+	Model  *ActiveRecord
+	Errors Errors
+}
+
+func (e ErrValidation) Error() string {
+	errors := strings.Join(e.Errors.FullMessages(), ", ")
+	return fmt.Sprintf("Model %v invalid%s", e.Model, errors)
+}
 
 type ErrInvalidValue struct {
 	AttrName string
@@ -61,16 +72,49 @@ func (m validatorsMap) extend(attrNames []string, validator Validator) {
 	}
 }
 
+type Errors struct {
+	errors map[string][]error
+}
+
+func (e *Errors) IsEmpty() bool {
+	return len(e.errors) == 0
+}
+
+func (e *Errors) Add(key string, err error) {
+	if e.errors != nil {
+		e.errors = make(map[string][]error)
+	}
+	errors := e.errors[key]
+	e.errors[key] = append(errors, err)
+}
+
+func (e *Errors) Delete(keys ...string) {
+	if len(keys) == 0 {
+		e.errors = make(map[string][]error)
+		return
+	}
+	for _, key := range keys {
+		delete(e.errors, key)
+	}
+}
+
+func (e *Errors) FullMessages() []string {
+	messages := make([]string, len(e.errors))
+	for _, keyErrors := range e.errors {
+		for _, err := range keyErrors {
+			messages = append(messages, err.Error())
+		}
+	}
+	return messages
+}
+
 type validations struct {
 	validators validatorsMap
-	errs       map[string][]error
+	errors     Errors
 }
 
 func newValidations(validators validatorsMap) *validations {
-	return &validations{
-		validators: validators.copy(),
-		errs:       make(map[string][]error),
-	}
+	return &validations{validators: validators.copy()}
 }
 
 func (v *validations) copy() *validations {
@@ -78,22 +122,25 @@ func (v *validations) copy() *validations {
 }
 
 func (v *validations) validate(rec *ActiveRecord) error {
+	v.errors.Delete()
+
 	for attr, validators := range v.validators {
 		for _, validator := range validators {
 			err := validator.Validate(rec, attr, rec.AccessAttribute(attr))
 			if err != nil {
-				return err
+				v.errors.Add(attr, err)
 			}
 		}
+	}
+
+	if !v.errors.IsEmpty() {
+		return ErrValidation{Model: rec, Errors: v.errors}
 	}
 	return nil
 }
 
-func (v *validations) Errors(attrName ...string) []error {
-	return nil
-}
-
-func (v *validations) ClearErrors() {
+func (v *validations) Errors() Errors {
+	return v.errors
 }
 
 type IntValidator func(v int64) error


### PR DESCRIPTION
This patch introduces `activerecord.Errors` type to record validation errors.