### PR TITLE
Types serialization

### DIFF
--- a/activerecord/persistence.go
+++ b/activerecord/persistence.go
@@ -24,7 +24,7 @@ type Persistence interface {
 
 type InsertOperation struct {
 	TableName      string
-	Values         map[string]interface{}
+	ColumnValues   []ColumnValue
 	OnDuplicate    string
 	ConflictTarget string
 }
@@ -45,6 +45,12 @@ type QueryOperation struct {
 	Text    string
 	Args    []interface{}
 	Columns []string
+}
+
+type ColumnValue struct {
+	Name  string
+	Type  Type
+	Value interface{}
 }
 
 type ColumnDefinition struct {

--- a/activerecord/record.go
+++ b/activerecord/record.go
@@ -213,9 +213,18 @@ func (r *ActiveRecord) Insert() (*ActiveRecord, error) {
 		return nil, err
 	}
 
+	columnValues := make([]ColumnValue, 0, len(r.attributes.values))
+	for name, value := range r.attributes.values {
+		columnValue := ColumnValue{
+			Name:  name,
+			Type:  r.attributes.keys[name].AttributeType(),
+			Value: value,
+		}
+		columnValues = append(columnValues, columnValue)
+	}
 	op := InsertOperation{
-		TableName: r.tableName,
-		Values:    r.attributes.values,
+		TableName:    r.tableName,
+		ColumnValues: columnValues,
 	}
 
 	id, err := r.conn.ExecInsert(r.Context(), &op)

--- a/activerecord/type.go
+++ b/activerecord/type.go
@@ -20,11 +20,15 @@ func (e ErrType) Error() string {
 	return fmt.Sprintf("invalid value '%v' for %s type", e.Value, e.TypeName)
 }
 
-type null struct {
+type Nil struct {
 	Type
 }
 
-func (n null) Deserialize(value interface{}) (interface{}, error) {
+func (n Nil) String() string {
+	return n.Type.String() + "?"
+}
+
+func (n Nil) Deserialize(value interface{}) (interface{}, error) {
 	if value == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
This patch starts using `Serialize` method for serialization of attributes
on writing the data to tables.