### PR TITLE
Connection-aware types lookup

### DIFF
--- a/activerecord/persistence.go
+++ b/activerecord/persistence.go
@@ -55,7 +55,7 @@ type ColumnValue struct {
 
 type ColumnDefinition struct {
 	Name         string
-	Type         string
+	Type         Type
 	NotNull      bool
 	IsPrimaryKey bool
 }
@@ -71,6 +71,7 @@ type Conn interface {
 	ExecQuery(ctx context.Context, op *QueryOperation, cb func(activesupport.Hash) bool) (err error)
 
 	ColumnDefinitions(ctx context.Context, tableName string) ([]ColumnDefinition, error)
+	LookupType(typeName string) (Type, error)
 
 	Close() error
 }
@@ -105,6 +106,10 @@ func (c *errConn) ExecDelete(context.Context, *DeleteOperation) error {
 
 func (c *errConn) ExecQuery(context.Context, *QueryOperation, func(activesupport.Hash) bool) error {
 	return c.err
+}
+
+func (c *errConn) LookupType(typeName string) (Type, error) {
+	return nil, c.err
 }
 
 func (c *errConn) ColumnDefinitions(ctx context.Context, tableName string) ([]ColumnDefinition, error) {

--- a/activerecord/relation.go
+++ b/activerecord/relation.go
@@ -103,24 +103,7 @@ func (r *R) init(ctx context.Context, tableName string) error {
 	}
 
 	for _, column := range definitions {
-		var columnType Type
-		switch column.Type {
-		case "integer":
-			columnType = new(Int64)
-		case "varchar", "text":
-			columnType = new(String)
-		case "float":
-			columnType = new(Float64)
-		case "boolean":
-			columnType = new(Boolean)
-		case "datetime":
-			columnType = new(DateTime)
-		case "date":
-			columnType = new(Date)
-		default:
-			panic(fmt.Errorf("unsupported type %q", column.Type))
-		}
-
+		columnType := column.Type
 		if !column.NotNull {
 			columnType = Nil{columnType}
 		}

--- a/activerecord/type.go
+++ b/activerecord/type.go
@@ -21,6 +21,14 @@ func (e ErrType) Error() string {
 	return fmt.Sprintf("invalid value '%v' for %s type", e.Value, e.TypeName)
 }
 
+type ErrUnsupportedType struct {
+	TypeName string
+}
+
+func (e ErrUnsupportedType) Error() string {
+	return fmt.Sprintf("unsupported type '%s'", e.TypeName)
+}
+
 type Nil struct {
 	Type
 }
@@ -109,6 +117,7 @@ func (*Boolean) Serialize(value interface{}) (interface{}, error) {
 const (
 	iso8601     = "2006-01-02 15:04:05.000000 MST"
 	iso8601Date = "2006-01-02"
+	iso8601Time = "15:04.05.000000 MST"
 )
 
 func parseTime(layout string, value interface{}) (interface{}, error) {
@@ -139,8 +148,7 @@ func formatTime(layout string, value interface{}) (interface{}, error) {
 	}
 }
 
-type DateTime struct {
-}
+type DateTime struct{}
 
 func (*DateTime) String() string { return "datetime" }
 
@@ -176,6 +184,26 @@ func (d *Date) Serialize(value interface{}) (interface{}, error) {
 	value, err := formatTime(iso8601Date, value)
 	if err != nil {
 		return nil, ErrType{TypeName: d.String(), Value: value}
+	}
+	return value, nil
+}
+
+type Time struct{}
+
+func (*Time) String() string { return "time" }
+
+func (t *Time) Deserialize(value interface{}) (interface{}, error) {
+	value, err := parseTime(iso8601Time, value)
+	if err != nil {
+		return nil, ErrType{TypeName: t.String(), Value: value}
+	}
+	return value, nil
+}
+
+func (t *Time) Serialize(value interface{}) (interface{}, error) {
+	value, err := formatTime(iso8601Time, value)
+	if err != nil {
+		return nil, ErrType{TypeName: t.String(), Value: value}
 	}
 	return value, nil
 }


### PR DESCRIPTION
This patch moves types conversion to the connection interface, so while querying
of columns definitions it returns types converted to the `Type` interface.

The patch also adds implementation of the `Time` type with timezone support.