### PR TITLE
`ActionConstraints` method for actions

### DIFF
--- a/actioncontroller/action.go
+++ b/actioncontroller/action.go
@@ -2,8 +2,6 @@ package actioncontroller
 
 import (
 	"context"
-
-	"github.com/activegraph/activegraph/activerecord"
 )
 
 type QueryAttribute struct {
@@ -33,7 +31,7 @@ type Result interface {
 
 type Action interface {
 	ActionName() string
-	ActionRequest() []activerecord.Attribute
+	ActionConstraints() Constraints
 	Process(ctx *Context) Result
 }
 
@@ -44,13 +42,13 @@ func (fn ActionFunc) Process(ctx *Context) Result {
 }
 
 type NamedAction struct {
-	Name    string
-	Request []activerecord.Attribute
+	Name        string
+	Constraints Constraints
 	ActionFunc
 }
 
-func (a *NamedAction) ActionRequest() []activerecord.Attribute {
-	return a.Request
+func (a *NamedAction) ActionConstraints() Constraints {
+	return a.Constraints
 }
 
 func (a *NamedAction) ActionName() string {

--- a/actioncontroller/callback.go
+++ b/actioncontroller/callback.go
@@ -34,9 +34,9 @@ func (cb *callbackAround) run(ctx *Context, action Action) Result {
 
 func (cb *callbackAround) chain(action Action) Action {
 	return &NamedAction{
-		Name:       action.ActionName(),
-		Request:    action.ActionRequest(),
-		ActionFunc: func(ctx *Context) Result { return cb.run(ctx, action) },
+		Name:        action.ActionName(),
+		Constraints: action.ActionConstraints(),
+		ActionFunc:  func(ctx *Context) Result { return cb.run(ctx, action) },
 	}
 }
 
@@ -93,8 +93,8 @@ func (cbs *callbacks) runCallbacks(ctx *Context, action Action) (result Result) 
 // TODO: Return `Action` instead of `NamedAction`.
 func (cbs *callbacks) override(action Action) *NamedAction {
 	return &NamedAction{
-		Name:       action.ActionName(),
-		Request:    action.ActionRequest(),
-		ActionFunc: func(ctx *Context) Result { return cbs.runCallbacks(ctx, action) },
+		Name:        action.ActionName(),
+		Constraints: action.ActionConstraints(),
+		ActionFunc:  func(ctx *Context) Result { return cbs.runCallbacks(ctx, action) },
 	}
 }

--- a/actioncontroller/controller.go
+++ b/actioncontroller/controller.go
@@ -145,7 +145,7 @@ func Initialize(init func(*C)) (*ActionController, error) {
 	init(&c)
 
 	for actionName, action := range c.actions {
-		action.Request = c.params[actionName]
+		action.Constraints = Constraints{Request: &StrongParameters{c.params[actionName]}}
 		action = c.callbacks.override(action)
 		c.actions[actionName] = action
 	}

--- a/actioncontroller/graphql/mapper.go
+++ b/actioncontroller/graphql/mapper.go
@@ -80,7 +80,10 @@ func (s *Schema) AddShowOp(model *activerecord.Relation) *graphql.FieldDefinitio
 func (s *Schema) AddCreateOp(
 	model *activerecord.Relation, action actioncontroller.Action,
 ) *graphql.FieldDefinition {
-	inputs := action.ActionRequest()
+	var inputs []activerecord.Attribute
+	if constraints := action.ActionConstraints(); constraints.Request != nil {
+		inputs = constraints.Request.Attributes
+	}
 
 	inputName := "Create" + CanonicalModelName(model.Name()) + "Input"
 	inputFields := make(graphql.FieldList, 0, len(inputs))


### PR DESCRIPTION
This patch extends action constraints with response attributes and match
predicate (just like for non-resourceful actions).

Closes #63