### PR TITLE
Persist assigned association

### DIFF
--- a/activerecord/association_test.go
+++ b/activerecord/association_test.go
@@ -1,0 +1,39 @@
+package activerecord
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/activegraph/activegraph/activesupport"
+)
+
+func TestActiveRecord_Persisted_AssignAssociation(t *testing.T) {
+	EstablishConnection(DatabaseConfig{
+		Adapter: "sqlite3", Database: t.Name() + ".db",
+	})
+
+	defer os.Remove(t.Name() + ".db")
+	defer RemoveConnection("primary")
+
+	Migrate(t.Name(), func(m *M) {
+		m.CreateTable("owners", func(t *Table) { t.String("name") })
+		m.CreateTable("targets", func(t *Table) { t.Int64("value") })
+		m.AddForeignKey("targets", "owners")
+	})
+
+	Owner := New("owner", func(r *R) { r.HasOne("target") })
+	Target := New("target", func(r *R) { r.BelongsTo("owner") })
+
+	// Insert an owner into the database, then create a new unpersisted target.
+	owner := Owner.Create(Hash{"name": "Kaneman"})
+	target := Target.New(Hash{"value": 42})
+
+	owner = owner.AssignAssociation("target", target)
+	owner.Expect("failed to assign target to the persisted owner")
+
+	assoc := target.Association("owner")
+	assoc.Expect("failed to access owner association")
+	require.Equal(t, owner.Unwrap().ID(), assoc.Unwrap().ID())
+}

--- a/activerecord/migration.go
+++ b/activerecord/migration.go
@@ -80,11 +80,7 @@ func (m *M) CreateTable(name string, init func(*Table)) {
 }
 
 func (m *M) AddForeignKey(owner, target string) {
-	// TODO: id is not necessary a primary key.
-	m.references[owner] = fmt.Sprintf(
-		`FOREIGN KEY ("%s_id") REFERENCES "%s" ("id")`,
-		strings.TrimSuffix(target, "s"), target,
-	)
+	m.references[owner] = target
 }
 
 func (m *M) prepareSQL(table *Table) string {
@@ -117,9 +113,12 @@ func (m *M) prepareSQL(table *Table) string {
 		fmt.Fprintf(&buf, `%s %s, `, columnName, sqlType)
 	}
 
-	if ref, ok := m.references[table.name]; ok {
-		fmt.Fprintf(&buf, `author_id INTEGER, `)
-		fmt.Fprintf(&buf, `%s, `, ref)
+	if targetTable, ok := m.references[table.name]; ok {
+		target := strings.TrimSuffix(targetTable, "s")
+
+		// TODO: id is not necessary a primary key.
+		fmt.Fprintf(&buf, `%s_id INTEGER, `, target)
+		fmt.Fprintf(&buf, `FOREIGN KEY ("%s_id") REFERENCES "%s" ("id") `, target, targetTable)
 	}
 	fmt.Fprintf(&buf, `PRIMARY KEY("%s"))`, primaryKey)
 	return buf.String()

--- a/activerecord/record.go
+++ b/activerecord/record.go
@@ -101,6 +101,16 @@ func (r RecordResult) Association(name string) RecordResult {
 	})}
 }
 
+func (r RecordResult) AssignAssociation(name string, target RecordResult) RecordResult {
+	return RecordResult{r.AndThen(func(r *ActiveRecord) Result[*ActiveRecord] {
+		if target.IsErr() {
+			return target
+		}
+		err := r.associations.AssignAssociation(name, target.Unwrap())
+		return ReturnRecord(r, err)
+	})}
+}
+
 func (r RecordResult) Collection(name string) CollectionResult {
 	if rec := r.Ok(); rec.IsSome() {
 		return rec.Unwrap().Collection(name)
@@ -207,14 +217,14 @@ func (r *ActiveRecord) Validate() error {
 	return r.validations.validate(r)
 }
 
-func (r *ActiveRecord) AssignAssociation(assocName string, rec *ActiveRecord) error {
-	if !r.HasAssociation(assocName) {
-		return ErrUnknownAssociation{RecordName: r.name, Assoc: assocName}
-	}
-
-	r.associations.values[assocName] = rec
-	return nil
-}
+// func (r *ActiveRecord) AssignAssociation(assocName string, rec *ActiveRecord) error {
+// 	if !r.HasAssociation(assocName) {
+// 		return ErrUnknownAssociation{RecordName: r.name, Assoc: assocName}
+// 	}
+//
+// 	r.associations.values[assocName] = rec
+// 	return nil
+// }
 
 func (r *ActiveRecord) Insert() (*ActiveRecord, error) {
 	if err := r.Validate(); err != nil {

--- a/activerecord/relation.go
+++ b/activerecord/relation.go
@@ -375,10 +375,8 @@ func (rel *Relation) Each(fn func(*ActiveRecord) error) error {
 				return false
 			}
 
-			e = rec.AssignAssociation(join.Relation.Name(), arec)
-			if lasterr = e; e != nil {
-				return false
-			}
+			// TODO: Fix this assignment, it should return an error.
+			rec.associations.set(join.Relation.Name(), arec)
 		}
 
 		if lasterr = fn(rec); lasterr != nil {


### PR DESCRIPTION
This patch persist assigned association. The implementation does not ensure
that owner is persisted yet. This is a target of future imporvement.